### PR TITLE
feature/FPHS-118

### DIFF
--- a/APCAppCore/APCAppCore/Library/Categories/NSDate+Helper.h
+++ b/APCAppCore/APCAppCore/Library/Categories/NSDate+Helper.h
@@ -36,6 +36,11 @@
 extern NSString * const NSDateDefaultDateFormat;
 extern NSString * const DateFormatISO8601DateOnly;
 
+/*
+ * Seems self-explanitory, but adding as a constant anyways
+ */
+static NSUInteger const kDateHelperDaysInAWeek = 7;
+
 @interface NSDate (Helper)
 
 /**
@@ -53,6 +58,7 @@ extern NSString * const DateFormatISO8601DateOnly;
  Got the rules from http://en.wikipedia.org/wiki/ISO_8601
  */
 - (NSString *) toStringInISO8601Format;
+
 
 /**
  Tries to interpret the specified string with any of
@@ -88,7 +94,10 @@ extern NSString * const DateFormatISO8601DateOnly;
 +(instancetype) tomorrowAtMidnight;
 +(instancetype) yesterdayAtMidnight;
 +(instancetype) weekAgoAtMidnight;
+
 +(instancetype) priorSundayAtMidnightFromDate:(NSDate *)date;
++(instancetype) nextSundayAtMidnightFromDate:(NSDate *)date;
+
 + (instancetype) dateWithYear:(NSInteger)year month:(NSInteger)month day:(NSInteger)day;
 
 - (BOOL) isEarlierThanDate: (NSDate*) otherDate;

--- a/APCAppCore/APCAppCore/Library/Categories/NSDate+Helper.m
+++ b/APCAppCore/APCAppCore/Library/Categories/NSDate+Helper.m
@@ -68,8 +68,6 @@ typedef enum : NSUInteger {
     APCDateDirectionBackwards,
 }   APCDateDirection;
 
-
-
 @implementation NSDate (Helper)
 
 /**
@@ -343,6 +341,12 @@ typedef enum : NSUInteger {
     NSDateComponents *components = [cal components:(NSCalendarUnitWeekOfYear | NSCalendarUnitMonth | NSCalendarUnitYear) fromDate:date];
     [components setWeekday:1];//Sunday
     return [cal dateFromComponents:components];
+}
+
++(instancetype)nextSundayAtMidnightFromDate:(NSDate *)date
+{
+    NSDate* priorSunday = [self priorSundayAtMidnightFromDate:date];
+    return [priorSunday dateByAddingDays:kDateHelperDaysInAWeek];
 }
 
 - (BOOL) isEarlierThanDate: (NSDate*) otherDate

--- a/APCAppCore/APCAppCore/Library/Objects/APCTasksReminderManager.h
+++ b/APCAppCore/APCAppCore/Library/Objects/APCTasksReminderManager.h
@@ -61,6 +61,14 @@ static NSUInteger const kAPCTaskReminderDayOfWeekSaturday    = 7;
  */
 @property (nonatomic) BOOL updatingRemindersRemovesAllLocalNotifications;
 
+/*
+ * Update reminder messaging
+ * This defualts to...
+ * "Please complete your TeamStudy activities today. Thank you for participating in the TeamStudy study!"
+ */
+- (void) setReminderMessage:(NSString*)reminderMessage
+            andDelayMessage:(NSString*)delayMessage;
+
 - (void) updateTasksReminder;
 - (void)manageTaskReminder:(APCTaskReminder *)reminder;
 + (NSArray*) reminderTimesArray;

--- a/APCAppCore/APCAppCore/Library/Objects/APCTasksReminderManager.h
+++ b/APCAppCore/APCAppCore/Library/Objects/APCTasksReminderManager.h
@@ -33,10 +33,33 @@
  
 #import <Foundation/Foundation.h>
 #import "APCTaskReminder.h"
+
+// These must be reflected by NSCalendar NSCalendarUnitWeekday, except for the EveryDay value
+static NSUInteger const kAPCTaskReminderDayOfWeekEveryDay    = 0;
+static NSUInteger const kAPCTaskReminderDayOfWeekSunday      = 1;
+static NSUInteger const kAPCTaskReminderDayOfWeekMonday      = 2;
+static NSUInteger const kAPCTaskReminderDayOfWeekTuesday     = 3;
+static NSUInteger const kAPCTaskReminderDayOfWeekWednesday   = 4;
+static NSUInteger const kAPCTaskReminderDayOfWeekThursday    = 5;
+static NSUInteger const kAPCTaskReminderDayOfWeekFriday      = 6;
+static NSUInteger const kAPCTaskReminderDayOfWeekSaturday    = 7;
+
 @interface APCTasksReminderManager : NSObject
 @property (nonatomic) BOOL reminderOn;
 @property (nonatomic, strong) NSString * reminderTime; //Should be an element of reminderTimesArray
 @property (strong, nonatomic, getter=reminders) NSMutableArray *reminders;
+
+/**
+ * The days of the week to repeat the reminder, defaults to include every day
+ * Object in the array must be of type APCTaskReminderDayOfWeek
+ */
+@property (nonatomic, strong) NSArray* daysOfTheWeekToRepeat;
+
+/*
+ * If true, all local notifications in this app (even ones that are not reminders) will be removed
+ * If false, the app will try and find only reminder notifications to delete; however this has inconsistant behavior
+ */
+@property (nonatomic) BOOL updatingRemindersRemovesAllLocalNotifications;
 
 - (void) updateTasksReminder;
 - (void)manageTaskReminder:(APCTaskReminder *)reminder;


### PR DESCRIPTION
Changes in AppCore to support weekday frequency reminders and also keep old reminder system working by default

For testing purposes, I preformed these 3 tests of satisfaction

Tests can be achieved by setting the date & time in iOS general settings to one minute before the expected time, and watching notification fire after time turns to 5:00 PM in any timezone.

Test Case 1:
New activities received on Sunday.
Notification appears on Sunday at 5PM
Notification appears on Tuesday at 5PM
Notifications appear next Sunday and Tuesday without opening the app

Test Case 2:
New activities received on Sunday.
Notification appears on Sunday at 5PM
Do all activities
No Notification appears on Tuesday at 5PM
Notifications appear next Sunday and Tuesday without opening the app

Test Case 3:
New activities received on Sunday.
Do all activities
No Notification appears on Sunday at 5PM
No Notification appears on Tuesday at 5PM
Notifications appear next Sunday and Tuesday without opening the app
